### PR TITLE
feature: configurable multichannel audio output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ PLAUD is a modular PyTorch framework for Differentiable Digital Signal Processin
 
 - **Explicit ControlSpace**: Authoritative source for control dimensions and rate.
 - **Modular synth routing**: Choose synth blocks and their parameters via config (no inspect-based magic).
+- **Multichannel output**: Set `audio.n_channels` to synthesize and export N audio channels (mono by default).
 - **Configurable losses**: Flexible list (e.g., MRSTFT-only by default) with per-component logging.
 - **Optional adversarial regime**: Gate discriminator and generator loss contributions by epoch.
 - **Prior integration**: Transformer Prior learns on exported control sequences; continuous controls at runtime.
@@ -119,6 +120,33 @@ Export details:
 - Use `--config-name/-cn` to select a file; use `++path.to.field=value` to override existing fields; use `+new.key=value` to add new keys.
 - Losses are a list with `name` and `weight`. MRSTFT-only is a sensible default.
 - Adversarial regime is optional and epoch-gated.
+
+## Multichannel
+
+`audio.n_channels` (default `1`) sets the number of audio channels the model synthesizes. Override it
+like any other field:
+
+```zsh
+python -m cli.train -cn experiment_features_only \
+  data.dataset_path=/absolute/path/to/dataset \
+  ++audio.n_channels=2
+```
+
+Behavior:
+
+- **Decoder per-channel heads**: a single shared latent/feature stream drives `n_channels` independent
+  sets of synth parameters, so each channel is synthesized separately. Channels differ only through
+  the decoder — the encoder and feature extractors consume a **mono downmix** of the input.
+- **Data**: preprocess with channels preserved — `utils/dataset_converter.py` keeps the source channel
+  layout by default (pass `--channels N` to force one). At load time, files with fewer channels than
+  `n_channels` are **zero-padded** and files with more are **cropped** to the first `n_channels`.
+- **Adversarial**: the discriminator runs per channel (each channel judged as an independent mono
+  example) and is averaged.
+- **Export**: `decode` exposes `n_channels` audio outputs (one nn~ signal outlet per channel), and
+  `encode` accepts `n_channels` inputs.
+- **Backward compatible**: at `n_channels=1` everything is identical to the mono model and existing
+  checkpoints load unchanged. Changing `n_channels` rebuilds the dataset cache (it is part of the
+  cache key).
 
 ## Testing
 

--- a/cli/export.py
+++ b/cli/export.py
@@ -77,26 +77,28 @@ class ScriptedDDSP(nn_tilde.Module):
 
     total_params = self.pretrained.num_params + self.pretrained.n_features
 
+    n_channels = self.pretrained.n_channels
+
     self.register_method(
       "decode",
       in_channels = total_params,
       in_ratio = self._nn_decode_ratio,
-      out_channels = 1, # number of output audio channels
+      out_channels = n_channels, # number of output audio channels
       # out_ratio = 1/3,
       out_ratio = 1,
       input_labels=[f'(signal) Latent Dimension {i}' for i in range(1, total_params+1)],
-      output_labels=['(signal) Audio Output'],
+      output_labels=[f'(signal) Audio Output {i}' for i in range(1, n_channels+1)],
       test_method=True,
     )
 
     if self.pretrained.latent_size > 0:
       self.register_method(
         "encode",
-        in_channels = 1,
+        in_channels = n_channels,
         in_ratio = 1,
         out_channels = self.pretrained.num_params,
         out_ratio = self.pretrained.resampling_factor,
-        input_labels=['(signal) Audio Input'],
+        input_labels=[f'(signal) Audio Input {i}' for i in range(1, n_channels+1)],
         output_labels=[f'(signal) Latent Dimension {i}' for i in range(1, self.pretrained.num_params+1)],
         test_method=True
       )
@@ -145,7 +147,8 @@ class ScriptedDDSP(nn_tilde.Module):
   def encode(self, audio: torch.Tensor):
     if self.pretrained.encoder is None:
       raise RuntimeError("encode() requested but the pretrained model has no encoder (latent_size=0)")
-    mu, scale = self.pretrained.encoder(audio.squeeze(1))
+    # Encoder downmixes the [B, n_channels, T] input internally
+    mu, scale = self.pretrained.encoder(audio)
     latents, _ = self.pretrained.encoder.reparametrize(mu, scale)
     latents = self.pretrained._smooth_latents(latents)
     latents = self.pretrained.normalize_latents(latents)
@@ -370,7 +373,7 @@ if __name__ == '__main__':
     scripted = ONNXDDSP(ddsp).to('cpu')
     torch.onnx.dynamo_export(
       scripted,
-      torch.zeros(1, 1, 2**14),
+      torch.zeros(1, ddsp.n_channels, 2**14),
     ).save(config.output_path)
   elif format == 'ts':
     # ugly workaround for the torchscript

--- a/cli/train.py
+++ b/cli/train.py
@@ -38,6 +38,7 @@ def main(cfg: DictConfig) -> None:
   fs = int(cfg.audio.fs)
   resampling_factor = int(cfg.model.resampling_factor)
   chunk_duration_s = float(cfg.audio.chunk_duration_s)
+  n_channels = int(getattr(cfg.audio, 'n_channels', 1))
   n_signal = int(fs * chunk_duration_s)
 
   # Paths
@@ -65,6 +66,7 @@ def main(cfg: DictConfig) -> None:
     resampling_factor=resampling_factor,
     control_space=control_space,
     transform_fn=transform_fn,
+    n_channels=n_channels,
   )
 
   # Dataloaders
@@ -94,6 +96,7 @@ def main(cfg: DictConfig) -> None:
     control_space=control_space,
     synth_configs=synth_configs,
     fs=fs,
+    n_channels=n_channels,
     resampling_factor=resampling_factor,
     latent_smoothing_kernel=int(cfg.model.latent_smoothing_kernel),
     decoder_gru_layers=int(cfg.model.decoder_gru_layers),

--- a/configs/experiment.yaml
+++ b/configs/experiment.yaml
@@ -7,6 +7,7 @@ experiment:
 audio:
   fs: 22050
   chunk_duration_s: 2.0
+  n_channels: 1
 
 data:
   dataset_path: /path/to/dataset

--- a/configs/experiment_features_only.yaml
+++ b/configs/experiment_features_only.yaml
@@ -7,6 +7,7 @@ experiment:
 audio:
   fs: 22050
   chunk_duration_s: 2.0
+  n_channels: 1
 
 data:
   dataset_path: /path/to/dataset

--- a/configs/experiment_hybrid.yaml
+++ b/configs/experiment_hybrid.yaml
@@ -7,6 +7,7 @@ experiment:
 audio:
   fs: 22050
   chunk_duration_s: 2.0
+  n_channels: 1
 
 data:
   dataset_path: /path/to/dataset

--- a/configs/experiment_latent_only.yaml
+++ b/configs/experiment_latent_only.yaml
@@ -7,6 +7,7 @@ experiment:
 audio:
   fs: 22050
   chunk_duration_s: 2.0
+  n_channels: 1
 
 data:
   dataset_path: /path/to/dataset

--- a/ddsp/audio_feature_dataset.py
+++ b/ddsp/audio_feature_dataset.py
@@ -23,12 +23,14 @@ class AudioFeatureDataset(Dataset):
                resampling_factor: int,
                control_space: ControlSpace,
                transform_fn: Callable = None,
+               n_channels: int = 1,
                device: str = 'cuda'):
     """
     Arguments:
       - dataset_path: str, the path to the dataset
       - n_signal: int, the size of the audio chunks, in samples
       - sampling_rate: int, the sampling rate of the audio
+      - n_channels: int, the number of audio channels (files are zero-padded/cropped to this count)
       - device: str, the device to use
     """
     self._device = device
@@ -37,6 +39,7 @@ class AudioFeatureDataset(Dataset):
     self._resampling_factor = resampling_factor
     self._transform_fn = transform_fn
     self._control_space = control_space
+    self._n_channels = n_channels
 
     # Build feature extractors from control space (feature fields only)
     self._extractor_specs: List[tuple[str, object, dict]] = []
@@ -63,14 +66,14 @@ class AudioFeatureDataset(Dataset):
   def _create_cache_key(self, dataset_path: str, n_signal: int, sampling_rate: int, resampling_factor: int, control_space: ControlSpace) -> str:
     """Create a unique cache key based on dataset parameters and control space."""
     field_sig = ";".join([f"{f.name}:{f.source}:{f.dim}:{f.extractor}:{sorted((f.params or {}).items())}" for f in control_space.fields])
-    key_string = f"{dataset_path}_{n_signal}_{sampling_rate}_{resampling_factor}_{field_sig}"
+    key_string = f"{dataset_path}_{n_signal}_{sampling_rate}_{resampling_factor}_{self._n_channels}ch_{field_sig}"
     return hashlib.md5(key_string.encode()).hexdigest()[:8]
 
   def _create_cache(self, dataset_path: str):
     """Load audio, process it, and save to LMDB."""
-    # Load and process audio
+    # Load and process audio -> [n_channels, T_total]
     self._audio = self._load_dataset(dataset_path).to(self._device)
-    self._dataset_length = int(len(self._audio) // self._n_signal)
+    self._dataset_length = int(self._audio.shape[-1] // self._n_signal)
 
     # Extract features
     self._features = self._extract_features()
@@ -102,7 +105,7 @@ class AudioFeatureDataset(Dataset):
     Save audio/features to LMDB in chunks to stay under LMDB's ~2 GiB per-value limit.
     """
     chunk_samps = 10_000_000
-    N = int(self._audio.shape[0])
+    N = int(self._audio.shape[-1])
     F = int(self._features.shape[-1])
 
     env = lmdb.open(
@@ -123,6 +126,7 @@ class AudioFeatureDataset(Dataset):
         "n_signal": self._n_signal,
         "sampling_rate": self._sampling_rate,
         "resampling_factor": self._resampling_factor,
+        "n_channels": int(self._n_channels),
         "total_samps": N,
         "feat_dim": F,
         "chunk_samps": chunk_samps,
@@ -137,7 +141,7 @@ class AudioFeatureDataset(Dataset):
     txn = env.begin(write=True)
     try:
       for idx, (a, b) in enumerate(self._iter_chunks(N, chunk_samps)):
-        aud = self._audio[a:b].detach().to("cpu").contiguous().to(torch.float32)
+        aud = self._audio[:, a:b].detach().to("cpu").contiguous().to(torch.float32)
         fea = self._features[a:b].detach().to("cpu").contiguous().to(torch.float32)
 
         aud_bytes = aud.numpy().tobytes(order="C")
@@ -167,11 +171,12 @@ class AudioFeatureDataset(Dataset):
       self._dataset_length = int(meta["dataset_length"])
       N = int(meta.get("total_samps", 0)) or (self._dataset_length * self._n_signal)
       F = int(meta.get("feat_dim", 0))
+      n_channels = int(meta.get("n_channels", 1))
       cs = int(meta["chunk_samps"])
       dtype = np.float32
 
       n_chunks = math.ceil(N / cs)
-      audio_cpu = torch.empty(N, dtype=torch.float32)
+      audio_cpu = torch.empty((n_channels, N), dtype=torch.float32)
       feats_cpu = torch.empty((N, F), dtype=torch.float32)
 
       pos = 0
@@ -185,10 +190,11 @@ class AudioFeatureDataset(Dataset):
           raise RuntimeError(f"Missing chunk {idx} in LMDB")
 
         a_arr = np.frombuffer(a_buf, dtype=dtype)
-        n_samps = a_arr.shape[0]
+        n_samps = a_arr.shape[0] // n_channels
+        a_arr = a_arr.reshape(n_channels, n_samps)
         f_arr = np.frombuffer(f_buf, dtype=dtype).reshape(n_samps, F)
 
-        audio_cpu[pos:pos+n_samps] = torch.from_numpy(a_arr)
+        audio_cpu[:, pos:pos+n_samps] = torch.from_numpy(a_arr)
         feats_cpu[pos:pos+n_samps] = torch.from_numpy(f_arr)
         pos += n_samps
 
@@ -205,12 +211,13 @@ class AudioFeatureDataset(Dataset):
     sample_start = int(idx * self._n_signal)
     sample_end = int(sample_start + self._n_signal)
 
-    if sample_end > len(self._audio):
-      audio = torch.cat([self._audio[sample_start:], self._audio[:sample_end - len(self._audio)]])
+    total_samps = self._audio.shape[-1]
+    if sample_end > total_samps:
+      audio = torch.cat([self._audio[:, sample_start:], self._audio[:, :sample_end - total_samps]], dim=-1)
       features = torch.cat([self._features[sample_start:], self._features[:sample_end - len(self._features)]])
 
     else:
-      audio = self._audio[sample_start:sample_end]
+      audio = self._audio[:, sample_start:sample_end]
       features = self._features[sample_start:sample_end]
 
     if self._transform_fn is not None:
@@ -255,18 +262,28 @@ class AudioFeatureDataset(Dataset):
     if len(filepaths) == 0:
       raise RuntimeError(f"No audio files found in path: {path}")
 
-    audio = torch.tensor([], device=self._device)
+    audio = torch.zeros((self._n_channels, 0), device=self._device)
     for filepath in filepaths:
-      x = self._load_file(filepath)
-      audio = torch.concat([audio, torch.from_numpy(x).to(self._device)], dim=0)
+      x = self._load_file(filepath)  # [n_channels, T]
+      audio = torch.concat([audio, torch.from_numpy(x).to(self._device)], dim=-1)
     return audio
 
 
   def _load_file(self, path: str):
     """
-    Load an audio file from a path.
+    Load an audio file from a path and conform it to n_channels.
+    Returns a numpy array of shape [n_channels, n_samples].
     """
-    audio, _ = li.load(path, sr = self._sampling_rate, mono = True)
+    audio, _ = li.load(path, sr = self._sampling_rate, mono = False)
+    # librosa returns [n_samples] for mono and [n_channels, n_samples] otherwise
+    audio = np.atleast_2d(audio)
+
+    n_channels = audio.shape[0]
+    if n_channels > self._n_channels:
+      audio = audio[:self._n_channels]
+    elif n_channels < self._n_channels:
+      padding = np.zeros((self._n_channels - n_channels, audio.shape[-1]), dtype=audio.dtype)
+      audio = np.concatenate([audio, padding], axis=0)
     return audio
 
 
@@ -275,10 +292,12 @@ class AudioFeatureDataset(Dataset):
     Extract features from the audio dataset.
     This is a placeholder function, as the actual feature extraction logic is not provided.
     """
-    # Compute audio-rate features for the full concatenated audio
+    # Compute audio-rate features from a mono downmix of the full concatenated audio.
+    # Sum over channels so a single shared feature/control stream drives all channels.
+    mono = self._audio.sum(dim=0)  # [T_total]
     feats = []
     for name, extractor, norm in self._extractor_specs:
-      feat = extractor(self._audio, self._sampling_rate)  # [N, C] at audio rate
+      feat = extractor(mono, self._sampling_rate)  # [N, C] at audio rate
       if feat.ndim == 1:
         feat = feat.unsqueeze(-1)
       # Apply optional normalization per field

--- a/ddsp/blocks.py
+++ b/ddsp/blocks.py
@@ -105,6 +105,11 @@ class VariationalEncoder(nn.Module):
     Returns:
       - mu, logvar: Tuple[torch.Tensor, torch.Tensor], the latent space tensor
     """
+    # Downmix multichannel input to mono. We sum (not average) so that zero-padded
+    # channels contribute nothing and a single channel passes through unchanged.
+    if audio.dim() == 3:
+      audio = audio.sum(dim=1)
+
     # Calculate Mel spectrogram
     melspec = self.melspec(audio)
 
@@ -172,14 +177,16 @@ class Decoder(nn.Module):
                n_params: int = 500,
                latent_size: int = 16,
                n_features: int = 4,
+               n_channels: int = 1,
                layer_sizes: List[int] = [32, 64, 128],
                output_mlp_layers: int = 3,
                gru_layers: int = 1,
                streaming: bool = False):
     """
     Arguments:
-      - n_params: int, the number of synthesis parameters
+      - n_params: int, the number of synthesis parameters (per channel)
       - latent_size: int, the size of the latent space
+      - n_channels: int, the number of output audio channels (one parameter head per channel)
       - layer_sizes: List[int], the sizes of the layers in the bottleneck
       - output_mlp_layers: int, the number of layers in the output MLP
       - gru_layers: int, the number of GRU layers in the decoder
@@ -188,6 +195,7 @@ class Decoder(nn.Module):
     super().__init__()
 
     self.n_params = n_params
+    self.n_channels = n_channels
     self.streaming = streaming
 
     # MLP mapping from the latent space
@@ -206,8 +214,8 @@ class Decoder(nn.Module):
     # Intermediary 3-layer MLP
     self.inter_mlp = _make_mlp(self.hidden_size, output_mlp_layers, self.hidden_size)
 
-    # Output layer predicting noiseband amplitudes, and sine frequencies and amplitudes
-    self.output_params = nn.Linear(self.hidden_size, n_params)
+    # Output layer predicting per-channel synth parameters (n_channels sets of n_params)
+    self.output_params = nn.Linear(self.hidden_size, n_channels * n_params)
 
 
   def forward(self, features: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
@@ -217,7 +225,8 @@ class Decoder(nn.Module):
       - features: torch.Tensor, the input features tensor [batch_size, n_features, n_signal]
       - z: torch.Tensor, the latent space tensor [batch_size, latent_size, n_signal]
     Returns:
-      - synth_params: torch.Tensor, the predicted synthesiser parameters
+      - synth_params: torch.Tensor[batch_size, n_channels, n_params, n_signal], the predicted
+        per-channel synthesiser parameters
     """
     # Pass latents through the input MLP
     z_transformed = self.input_latent_bottleneck(z)
@@ -238,10 +247,13 @@ class Decoder(nn.Module):
     # Pass through the intermediary MLP
     x = self.inter_mlp(x)
 
-    # Pass through the output layer
+    # Pass through the output layer -> [batch_size, n_signal, n_channels * n_params]
     output = _scaled_sigmoid(self.output_params(x))
 
-    return output.permute(0, 2, 1)
+    # Expose the channel axis -> [batch_size, n_channels, n_params, n_signal]
+    batch_size, n_signal = output.shape[0], output.shape[1]
+    output = output.view(batch_size, n_signal, self.n_channels, self.n_params)
+    return output.permute(0, 2, 3, 1)
 
 
   def positional_encoding(self, d_model, length):

--- a/ddsp/ddsp.py
+++ b/ddsp/ddsp.py
@@ -44,6 +44,7 @@ class DDSP(L.LightningModule):
                control_space: ControlSpace,
                synth_configs: List[Dict[Any, Any]] = [],
                fs: int = 44100,
+               n_channels: int = 1,
                encoder_ratios: List[int] = [8, 4, 2],
                latent_smoothing_kernel: int = 1,
                n_melbands: int = 128,
@@ -76,6 +77,7 @@ class DDSP(L.LightningModule):
     self._device = device
     self._plateau_patience = plateau_patience
     self.fs = fs
+    self.n_channels = n_channels
     # Control space is the single source of dims
     self.control_space = control_space
     self.latent_size = self.control_space.latent_dim
@@ -152,6 +154,7 @@ class DDSP(L.LightningModule):
       n_params=self._total_synth_params,
       latent_size=max(self.latent_size, 1),
       n_features=max(self.feature_dim, 1),
+      n_channels=n_channels,
       layer_sizes=(np.array(decoder_ratios)*capacity).tolist(),
       gru_layers=decoder_gru_layers,
       streaming=streaming,
@@ -406,8 +409,8 @@ class DDSP(L.LightningModule):
       z = z[:, :T_min, :]
 
     synth_params = self.decoder(features_for_decoder, z)
-    # Decoder outputs [B, n_params, T_ctl]; synthesize to audio-rate
-    assert synth_params.shape[1] == self._total_synth_params, "decoder param size mismatch"
+    # Decoder outputs [B, n_channels, n_params, T_ctl]; synthesize to audio-rate
+    assert synth_params.shape[2] == self._total_synth_params, "decoder param size mismatch"
     signal = self._synthesize(synth_params)
     return signal
 
@@ -451,8 +454,8 @@ class DDSP(L.LightningModule):
       self.toggle_optimizer(opt_disc)
 
       # D(real) and D(fake.detach()) with grads ONLY for D
-      pred_real = self._discriminator(x_audio.float())
-      pred_fake_det = self._discriminator(y_audio.float().detach())
+      pred_real = self._discriminate(x_audio.float())
+      pred_fake_det = self._discriminate(y_audio.float().detach())
 
       self.log("D(real)", sum([out[-1].mean() for out in pred_real]).item(), prog_bar=True, logger=True)
       self.log("D(fake)", sum([out[-1].mean() for out in pred_fake_det]).item(), prog_bar=True, logger=True)
@@ -488,9 +491,9 @@ class DDSP(L.LightningModule):
     if self._adversarial_loss and self.current_epoch >= self._adv_g_start_epoch:
       self.toggle_optimizer(opt_ddsp)                 # freezes D params for this block
 
-      pred_real = self._discriminator(x_audio.float())
+      pred_real = self._discriminate(x_audio.float())
       # D(fake) WITHOUT detach, but D is frozen so grads flow to G only
-      pred_fake = self._discriminator(y_audio.float())
+      pred_fake = self._discriminate(y_audio.float())
 
       # Generator hinge term: -E[D(fake)]
       for out in pred_fake:
@@ -678,6 +681,18 @@ class DDSP(L.LightningModule):
   #   self._validation_index += 1
 
 
+  def _discriminate(self, audio: torch.Tensor):
+    """
+    Run the (mono) discriminator on each channel independently by folding the channel axis
+    into the batch. Downstream hinge/feature-matching reductions then average over batch*channels,
+    i.e. a per-channel discriminator. Accepts [B, N, T] or legacy [B, T]/[B, 1, T].
+    """
+    if audio.dim() == 2:
+      audio = audio.unsqueeze(1)
+    B, N, T = audio.shape
+    return self._discriminator(audio.reshape(B * N, 1, T))
+
+
   def _synthesize(self, params: torch.Tensor, waveshaping_factor: float=0.0, limit_components: float=0.0) -> torch.Tensor:
     """
     Synthesizes a signal from the predicted amplitudes and the baked noise bands.
@@ -690,6 +705,13 @@ class DDSP(L.LightningModule):
     Returns:
       - signal: torch.Tensor[batch_size, sig_length], the synthesized signal
     """
+    # Fold the channel axis into the batch so each synth processes [B*N, n_params, T]
+    # transparently. Legacy/JIT callers may pass [B, n_params, T]; treat it as a single channel.
+    if params.dim() == 3:
+      params = params.unsqueeze(1)
+    B, N = params.shape[0], params.shape[1]
+    params = params.reshape(B * N, params.shape[2], params.shape[3])
+
     params_idx = 0
     audio = []
 
@@ -707,7 +729,9 @@ class DDSP(L.LightningModule):
         # Default call with parameters only
         audio.append(synth(synth_params))
 
-    return torch.sum(torch.hstack(audio), dim=1, keepdim=True)
+    # Sum across synths -> [B*N, 1, T], then restore the channel axis -> [B, N, T]
+    mixed = torch.sum(torch.hstack(audio), dim=1, keepdim=True)
+    return mixed.reshape(B, N, mixed.shape[-1])
 
 
   def _reconstruction_loss(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
@@ -721,6 +745,9 @@ class DDSP(L.LightningModule):
       min_length = min(x.shape[-1], y.shape[-1])
       x = x[..., :min_length]
       y = y[..., :min_length]
+    # Fold channels into the batch so each loss sees mono [B*N, 1, T] (per-channel averaged).
+    x = x.reshape(x.shape[0] * x.shape[1], 1, x.shape[-1])
+    y = y.reshape(y.shape[0] * y.shape[1], 1, y.shape[-1])
 
     total = 0.0
     # Each loss function may expect shapes [B,1,T] or [B,T]; try both
@@ -745,6 +772,9 @@ class DDSP(L.LightningModule):
       min_length = min(x.shape[-1], y.shape[-1])
       x = x[..., :min_length]
       y = y[..., :min_length]
+    # Fold channels into the batch so each loss sees mono [B*N, 1, T] (per-channel averaged).
+    x = x.reshape(x.shape[0] * x.shape[1], 1, x.shape[-1])
+    y = y.reshape(y.shape[0] * y.shape[1], 1, y.shape[-1])
 
     comps: Dict[str, torch.Tensor] = {}
     for loss_fn, _w in self._loss_items:

--- a/ddsp/rave_transforms.py
+++ b/ddsp/rave_transforms.py
@@ -51,7 +51,10 @@ class Compose(Transform):
     def __call__(self, x: torch.Tensor) -> torch.Tensor:
         for elm in self.transform_list:
             dev = x.device
-            x = elm(x).squeeze().to(dev)
+            x = elm(x).to(dev)
+            # Drop only a leading singleton (batch) dim, preserving the channel axis [C, T]
+            while x.dim() > 2 and x.shape[0] == 1:
+                x = x.squeeze(0)
         return x
 
 

--- a/utils/dataset_converter.py
+++ b/utils/dataset_converter.py
@@ -4,7 +4,7 @@ import subprocess
 from tqdm import tqdm
 from glob import glob
 
-def convert_to_wav(input_dir, output_dir, sampling_rate, highpass=None):
+def convert_to_wav(input_dir, output_dir, sampling_rate, highpass=None, channels=None):
     # Check if output directory exists, create it if not
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
@@ -17,15 +17,17 @@ def convert_to_wav(input_dir, output_dir, sampling_rate, highpass=None):
         file_name = audio_file.split('/')[-1]
         output_file_path = os.path.join(output_dir, os.path.splitext(file_name)[0] + '.wav')
 
-        # Command to convert audio file to mono, 16-bit WAV, and specified sampling rate
+        # Command to convert audio file to 16-bit WAV at the specified sampling rate.
+        # Source channels are preserved by default; pass --channels to force a fixed count.
         command = [
             'sox',
             audio_file,
             '-r', str(sampling_rate),  # Sample rate
-            '-c', '1',                 # Mono
             '-b', '16',                # 16-bit
-            output_file_path
         ]
+        if channels is not None:
+            command.extend(['-c', str(channels)])  # Force channel count
+        command.append(output_file_path)
 
         if highpass:
             command.extend(['highpass', str(highpass)])
@@ -39,7 +41,8 @@ if __name__ == "__main__":
     parser.add_argument('--output_dir', type=str, help='Output directory for converted audio files')
     parser.add_argument('--sampling_rate', type=int, default=44100, help='Sampling rate for the output audio files')
     parser.add_argument('--highpass', type=int, default=None, help='High-pass filter cutoff frequency in Hz')
+    parser.add_argument('--channels', type=int, default=None, help='Force a fixed channel count (default: preserve source channels)')
 
     args = parser.parse_args()
 
-    convert_to_wav(args.input_dir, args.output_dir, args.sampling_rate, args.highpass)
+    convert_to_wav(args.input_dir, args.output_dir, args.sampling_rate, args.highpass, args.channels)


### PR DESCRIPTION
### Summary

Adds support for synthesizing and exporting **N audio channels** instead of mono, controlled by a single `audio.n_channels` config  value. The architecture stays almost entirely shared: a single mono-downmix latent feature stream drives all channels, and channels diverge only at the decoder's per-channel parameter heads. Each synth processes channels by folding `N` into the batch dimension, so synth internals (and the shared filterbank) are untouched.