### PR TITLE
shrink the noise bank, fix multichannel prior caching, reintroduce β  warmup

### DIFF
--- a/cli/train.py
+++ b/cli/train.py
@@ -12,7 +12,7 @@ import shutil
 from torch.utils.data import DataLoader, Subset, random_split
 from ddsp import DDSP, AudioFeatureDataset
 from ddsp.synths import BendableNoiseBandSynth
-from ddsp.callbacks import BetaWarmupCallback
+from ddsp.callbacks import BetaWarmupEpochCallback
 from ddsp.interfaces import build_control_space
 from ddsp.augmentations import build_audio_augmentation_pipeline
 from ddsp.registry import SYNTHS
@@ -121,7 +121,11 @@ def main(cfg: DictConfig) -> None:
   # Callbacks
   callbacks = []
   if 'beta' in cfg.model:
-    callbacks.append(BetaWarmupCallback(beta=float(cfg.model.beta), start_steps=50, end_steps=100))
+    callbacks.append(BetaWarmupEpochCallback(
+      beta=float(cfg.model.beta.target),
+      start_epoch=int(cfg.model.beta.start_epoch),
+      end_epoch=int(cfg.model.beta.end_epoch),
+    ))
 
   callbacks.append(ModelCheckpoint(dirpath=synth_training_path, filename='best', monitor='val_loss', mode='min', save_top_k=1, save_last=True))
 

--- a/configs/experiment.yaml
+++ b/configs/experiment.yaml
@@ -48,7 +48,10 @@ model:
   learning_rate: 1e-4
   plateau_patience: 100000
   capacity: 32
-  # beta: 0.001  # optional beta warmup target
+  beta:
+    target: 0.001     # target β for the β-VAE KLD term
+    start_epoch: 100   # hold β at 0 until this epoch
+    end_epoch: 200     # linearly ramp β to target by this epoch
 
 losses:
   - type: MRSTFT

--- a/configs/experiment_features_only.yaml
+++ b/configs/experiment_features_only.yaml
@@ -52,6 +52,10 @@ model:
   learning_rate: 1e-4
   plateau_patience: 100000
   capacity: 32
+  beta:
+    target: 0.001     # target β for the β-VAE KLD term
+    start_epoch: 100   # hold β at 0 until this epoch
+    end_epoch: 200     # linearly ramp β to target by this epoch
 
 losses:
   - type: MRSTFT

--- a/configs/experiment_hybrid.yaml
+++ b/configs/experiment_hybrid.yaml
@@ -48,6 +48,10 @@ model:
   learning_rate: 1e-4
   plateau_patience: 100000
   capacity: 32
+  beta:
+    target: 0.001     # target β for the β-VAE KLD term
+    start_epoch: 100   # hold β at 0 until this epoch
+    end_epoch: 200     # linearly ramp β to target by this epoch
 
 losses:
   - type: MRSTFT

--- a/configs/experiment_latent_only.yaml
+++ b/configs/experiment_latent_only.yaml
@@ -32,6 +32,10 @@ model:
   learning_rate: 1e-4
   plateau_patience: 100000
   capacity: 32
+  beta:
+    target: 0.001     # target β for the β-VAE KLD term
+    start_epoch: 100   # hold β at 0 until this epoch
+    end_epoch: 200     # linearly ramp β to target by this epoch
 
 losses:
   - type: MRSTFT

--- a/ddsp/ddsp.py
+++ b/ddsp/ddsp.py
@@ -40,6 +40,10 @@ class DDSP(L.LightningModule):
     - adversarial_loss: bool, enable adversarial training
     - device: str, device
   """
+
+  # Fixed (non-configurable) scaling on the KLD term. The β schedule modulates
+  # this further; recovered from the pre-refactor default (commit bb76ec9).
+  _KLD_WEIGHT = 0.0001
   def __init__(self,
                control_space: ControlSpace,
                synth_configs: List[Dict[Any, Any]] = [],
@@ -488,7 +492,7 @@ class DDSP(L.LightningModule):
     recons_loss = self._reconstruction_loss(y_audio.float(), x_audio.float())
     # Log individual loss components for visibility
     self._log_loss_components(y_audio.float(), x_audio.float(), split='train')
-    ddsp_loss = recons_loss + self._beta * kld_loss  # adv term added below if enabled
+    ddsp_loss = recons_loss + self._KLD_WEIGHT * self._beta * kld_loss  # adv term added below if enabled
 
     if self._adversarial_loss and self.current_epoch >= self._adv_g_start_epoch:
       self.toggle_optimizer(opt_ddsp)                 # freezes D params for this block

--- a/ddsp/filterbank.py
+++ b/ddsp/filterbank.py
@@ -2,6 +2,7 @@ from torch import nn
 import torch
 import numpy as np
 import scipy.signal as signal
+import math
 
 from typing import List, Any, Optional
 
@@ -46,16 +47,11 @@ class FilterBank(nn.Module):
     # self.register_buffer('noisebands', torch.from_numpy(np.array(self._bake_noisebands())))
 
     # optimisation: store the baked noisebands as int8 + per-band float scales instead of float32
-    nb = torch.from_numpy(np.array(self._bake_noisebands())) # => [n_filters, n_signal]
-    scale = (nb.abs().amax(dim=1, keepdim=True) / 127.0).clamp(min=1e-12) # => [n_filters, 1]
-    q = torch.round(nb / scale).clamp(-127, 127).to(torch.int8)
-    self.register_buffer('_noisebands_q', q)
-    self.register_buffer('_noisebands_scale', scale)
-
-  @property
-  def noisebands(self) -> torch.Tensor:
-    """Dequantized noise bands [n_filters, n_signal], reconstructed from int8 storage"""
-    return self._noisebands_q.float() * self._noisebands_scale
+    _nb = torch.from_numpy(np.array(self._bake_noisebands())).float()  # [n_filters, n_signal]
+    _nb_scale = (_nb.abs().amax(dim=1) / 127.0).clamp_min(1e-12)       # [n_filters] per-band
+    _nb_q = torch.round(_nb / _nb_scale.unsqueeze(1)).clamp(-128.0, 127.0).to(torch.int8)
+    self.register_buffer('noisebands', _nb_q, persistent=False)
+    self.register_buffer('noisebands_scale', _nb_scale, persistent=False)  # [n_filters]
 
 
   def _calculate_boundaries(self):
@@ -165,5 +161,3 @@ class FilterBank(nn.Module):
 
     # return the filter (h)
     return signal.firwin(numtaps=numtaps, cutoff=band, window=('kaiser', beta), scale=True, fs=self._fs, pass_zero=pass_zero)
-
-

--- a/ddsp/filterbank.py
+++ b/ddsp/filterbank.py
@@ -43,7 +43,19 @@ class FilterBank(nn.Module):
     self._boundaries = self._calculate_boundaries()
 
     self._filters = self._build_filterbank(self._boundaries)
-    self.register_buffer('noisebands', torch.from_numpy(np.array(self._bake_noisebands())))
+    # self.register_buffer('noisebands', torch.from_numpy(np.array(self._bake_noisebands())))
+
+    # optimisation: store the baked noisebands as int8 + per-band float scales instead of float32
+    nb = torch.from_numpy(np.array(self._bake_noisebands())) # => [n_filters, n_signal]
+    scale = (nb.abs().amax(dim=1, keepdim=True) / 127.0).clamp(min=1e-12) # => [n_filters, 1]
+    q = torch.round(nb / scale).clamp(-127, 127).to(torch.int8)
+    self.register_buffer('_noisebands_q', q)
+    self.register_buffer('_noisebands_scale', scale)
+
+  @property
+  def noisebands(self) -> torch.Tensor:
+    """Dequantized noise bands [n_filters, n_signal], reconstructed from int8 storage"""
+    return self._noisebands_q.float() * self._noisebands_scale
 
 
   def _calculate_boundaries(self):

--- a/ddsp/prior/lmdb_cache.py
+++ b/ddsp/prior/lmdb_cache.py
@@ -28,6 +28,7 @@ def _create_cache_key(
     n_signal: int,
     sampling_rate: int,
     resampling_factor: int,
+    n_channels: int,
     control_space: ControlSpace,
     ddsp_checkpoint_path: str,
     seq_len: int,
@@ -40,7 +41,7 @@ def _create_cache_key(
     ckpt_stat = os.stat(ddsp_checkpoint_path)
     ckpt_sig = f"{ddsp_checkpoint_path}:{int(ckpt_stat.st_mtime)}:{int(ckpt_stat.st_size)}"
     field_sig = _control_space_signature(control_space)
-    key_string = f"{dataset_path}_{n_signal}_{sampling_rate}_{resampling_factor}_{seq_len}_{stride_factor}_{field_sig}_{ckpt_sig}"
+    key_string = f"{dataset_path}_{n_signal}_{sampling_rate}_{resampling_factor}_{n_channels}_{seq_len}_{stride_factor}_{field_sig}_{ckpt_sig}"
     return hashlib.md5(key_string.encode()).hexdigest()[:8]
 
 
@@ -125,7 +126,9 @@ def ensure_prior_controls_lmdb(
     num_controls: Optional[int] = None
 
     l_chunk = sr * 40
-    n_chunks_audio = (audio.size(0) + l_chunk - 1) // l_chunk
+    # audio is [n_channels, T_total]; chunk along the time axis (last dim).
+    T_total = int(audio.shape[-1])
+    n_chunks_audio = (T_total + l_chunk - 1) // l_chunk
 
     # Write in batched transactions; per-key begin/commit is extremely slow.
     commit_bytes = 256 * 1024**2  # ~256 MiB
@@ -133,9 +136,9 @@ def ensure_prior_controls_lmdb(
     txn = env.begin(write=True)
     try:
         for i_chunk in range(int(n_chunks_audio)):
-            a = audio[i_chunk * l_chunk : (i_chunk + 1) * l_chunk]
+            a = audio[:, i_chunk * l_chunk : (i_chunk + 1) * l_chunk]  # [n_channels, chunk_len]
             f = features[i_chunk * l_chunk : (i_chunk + 1) * l_chunk]
-            if a.numel() < rf:
+            if a.shape[-1] < rf:
                 continue
 
             # Downsample features to control frames
@@ -164,6 +167,12 @@ def ensure_prior_controls_lmdb(
                     z = torch.zeros(feat.size(0), Dz, device=feat.device, dtype=feat.dtype)
                 else:
                     z = torch.empty((feat.size(0), 0), device=feat.device, dtype=feat.dtype)
+
+            # Align time dims: encoder downsampling may differ from the feature
+            # downsampling by ±1, especially on the trailing partial chunk.
+            T_ctl = min(feat.size(0), z.size(0))
+            feat = feat[:T_ctl]
+            z = z[:T_ctl]
 
             seq = torch.cat([feat, z], dim=-1)  # [T_ctl, D]
 
@@ -251,6 +260,7 @@ def build_or_load_prior_cache_from_cfg(
     resampling_factor = int(cfg.model.resampling_factor)
     chunk_duration_s = float(cfg.audio.chunk_duration_s)
     n_signal = int(fs * chunk_duration_s)
+    n_channels = int(cfg.audio.n_channels)
 
     dataset_path = str(cfg.data.dataset_path)
 
@@ -263,6 +273,7 @@ def build_or_load_prior_cache_from_cfg(
         n_signal=n_signal,
         sampling_rate=fs,
         resampling_factor=resampling_factor,
+        n_channels=n_channels,
         control_space=control_space,
         ddsp_checkpoint_path=ddsp_checkpoint_path,
         seq_len=seq_len,

--- a/ddsp/synths/synths.py
+++ b/ddsp/synths/synths.py
@@ -5,7 +5,7 @@ import torchaudio
 import torch.nn.functional as F
 import numpy as np
 
-from ddsp.filterbank import FilterBank
+from ddsp.filterbank import FilterBank, LazyFilterBank
 # from ddsp.sgd.sinusoidal_gradient_descent.core import complex_oscillator
 
 
@@ -71,122 +71,122 @@ class BaseSynth(nn.Module):
     return cls(**params)
 
 
-@register_synth
-class NoiseBandSynth(BaseSynth):
-  """
-  A synthesiser that generates a mixture noise bands from amplitudes.
+# @register_synth
+# class NoiseBandSynth(BaseSynth):
+#   """
+#   A synthesiser that generates a mixture noise bands from amplitudes.
 
-  Arguments:
-    - n_filters: int, the number of filters in the filterbank
-    - fs: int, the sampling rate of the input signal
-    - resampling_factor: int, the internal up / down sampling factor for the signal
-    - device: str, the device to use
-  """
+#   Arguments:
+#     - n_filters: int, the number of filters in the filterbank
+#     - fs: int, the sampling rate of the input signal
+#     - resampling_factor: int, the internal up / down sampling factor for the signal
+#     - device: str, the device to use
+#   """
 
-  def __init__(self, n_filters: int = 2048, fs: int = 44100, resampling_factor: int = 32, device: str = 'cuda'):
-    super().__init__()
-    self._resampling_factor = resampling_factor
-    self._device = device
+#   def __init__(self, n_filters: int = 2048, fs: int = 44100, resampling_factor: int = 32, device: str = 'cuda'):
+#     super().__init__()
+#     self._resampling_factor = resampling_factor
+#     self._device = device
 
-    self._filterbank = FilterBank(
-      n_filters=n_filters,
-      fs=fs,
-      device=self._device
-    )
+#     self._filterbank = FilterBank(
+#       n_filters=n_filters,
+#       fs=fs,
+#       device=self._device
+#     )
 
-    # Shift of the noisebands between inferences, to maintain continuity
-    self._noisebands_shift = 0
+#     # Shift of the noisebands between inferences, to maintain continuity
+#     self._noisebands_shift = 0
 
-    # Precompute blocked noisebands for fast batch=1 inference synthesis.
-    # Reshape [n_filters, band_len] -> [n_blocks, n_filters, rf] where n_blocks = band_len // rf
-    # Each block corresponds to one control frame's worth of audio samples.
-    nb = self._filterbank.noisebands # [n_filters, band_len]
-    n_f, band_len = nb.shape
-    n_blocks = band_len // resampling_factor
-    nb_blocked = nb.reshape(n_f, n_blocks, resampling_factor).permute(1, 0, 2).contiguous()
-    self.register_buffer('_nb_blocked', nb_blocked, persistent=False) # -> [n_blocks, n_filters, rf]
-
-
-  @property
-  def n_params(self):
-    return len(self._filterbank.noisebands)
+#     # Precompute blocked noisebands for fast batch=1 inference synthesis.
+#     # Reshape [n_filters, band_len] -> [n_blocks, n_filters, rf] where n_blocks = band_len // rf
+#     # Each block corresponds to one control frame's worth of audio samples.
+#     nb = self._filterbank.noisebands # [n_filters, band_len]
+#     n_f, band_len = nb.shape
+#     n_blocks = band_len // resampling_factor
+#     nb_blocked = nb.reshape(n_f, n_blocks, resampling_factor).permute(1, 0, 2).contiguous()
+#     self.register_buffer('_nb_blocked', nb_blocked, persistent=False) # -> [n_blocks, n_filters, rf]
 
 
-  @property
-  def jit_name(self):
-    return "NoiseBandSynth"
+#   @property
+#   def n_params(self):
+#     return len(self._filterbank.noisebands)
 
 
-  def forward(self, amplitudes: torch.Tensor, limit_components: float = 0.0, waveshaping_factor: float = 0.0) -> torch.Tensor:
-    """
-    Synthesizes a signal from the predicted amplitudes and the baked noise bands.
-    Args:
-      - amplitudes: torch.Tensor[batch_size, n_bands, n_ctrl], the predicted amplitudes of the noise bands
-      - limit_components: float, the attenuation factor for the number of used bands
-      - waveshaping_factor: float, does nothing, it is here for the JIT compatibility with other synth classes
-    Returns:
-      - signal: torch.Tensor[batch_size, 1, sig_length], the synthesized signal
-    """
-    limit_components = max(0.0, min(limit_components, 1.0))
-    rf = int(self._resampling_factor)
-    noisebands = self._noisebands  # [n_filters, band_len]
-    band_len = noisebands.shape[-1]
-    n_ctrl = amplitudes.shape[-1]
-    total_len = n_ctrl * rf
-    batch_size = amplitudes.shape[0]
+#   @property
+#   def jit_name(self):
+#     return "NoiseBandSynth"
 
-    if self.training:
-      # Roll noisebands randomly during training to avoid overfitting to specific noise values
-      noisebands = torch.roll(noisebands, shifts=int(torch.randint(0, band_len, size=(1,), device=noisebands.device)), dims=-1)
 
-    # Track shift for streaming continuity (start_pos is always a multiple of rf)
-    start_pos = self._noisebands_shift % band_len
-    self._noisebands_shift = (self._noisebands_shift + total_len) % band_len
+#   def forward(self, amplitudes: torch.Tensor, limit_components: float = 0.0, waveshaping_factor: float = 0.0) -> torch.Tensor:
+#     """
+#     Synthesizes a signal from the predicted amplitudes and the baked noise bands.
+#     Args:
+#       - amplitudes: torch.Tensor[batch_size, n_bands, n_ctrl], the predicted amplitudes of the noise bands
+#       - limit_components: float, the attenuation factor for the number of used bands
+#       - waveshaping_factor: float, does nothing, it is here for the JIT compatibility with other synth classes
+#     Returns:
+#       - signal: torch.Tensor[batch_size, 1, sig_length], the synthesized signal
+#     """
+#     limit_components = max(0.0, min(limit_components, 1.0))
+#     rf = int(self._resampling_factor)
+#     noisebands = self._noisebands  # [n_filters, band_len]
+#     band_len = noisebands.shape[-1]
+#     n_ctrl = amplitudes.shape[-1]
+#     total_len = n_ctrl * rf
+#     batch_size = amplitudes.shape[0]
 
-    # Apply band mask at control rate (mean is identical pre- vs post-upsample)
-    if limit_components > 0:
-      max_bands = max(int(self.n_params * (1 - limit_components)), 1)
-      _, indices = torch.topk(amplitudes.mean(dim=-1), max_bands, dim=1)
-      mask = torch.zeros(batch_size, self.n_params, 1, dtype=amplitudes.dtype, device=amplitudes.device)
-      mask.scatter_(1, indices.unsqueeze(-1), 1)
-      amplitudes = amplitudes * mask
+#     if self.training:
+#       # Roll noisebands randomly during training to avoid overfitting to specific noise values
+#       noisebands = torch.roll(noisebands, shifts=int(torch.randint(0, band_len, size=(1,), device=noisebands.device)), dims=-1)
 
-    # Fast inference path (any batch size, including folded multichannel): periodic blocked BMM,
-    # handles limit_components too. _nb_blocked: [n_blocks, n_filters, rf], each block = one
-    # control frame's audio. All rows share the same noisebands and start_pos, so they are
-    # batched together over the leading dim.
-    if not self.training:
-      n_blocks = self._nb_blocked.shape[0]
-      start_block = start_pos // rf
-      nb_blocked = self._nb_blocked.to(amplitudes.dtype)  # match dtype (noisebands are float64)
-      out = torch.empty(batch_size, n_ctrl, rf, dtype=amplitudes.dtype, device=amplitudes.device)
-      t, b = 0, start_block
-      while t < n_ctrl:
-        avail = n_blocks - b
-        take = min(avail, n_ctrl - t)
-        # amplitudes[:, :, t:t+take]: [B, n_filters, take]; nb_blocked[b:b+take]: [take, n_filters, rf].
-        # Contract over filters per control frame -> [B, take, rf].
-        out[:, t:t+take, :] = torch.einsum('bft,tfr->btr', amplitudes[:, :, t:t+take], nb_blocked[b:b+take])
-        t += take; b = (b + take) % n_blocks
-      return out.reshape(batch_size, 1, -1)
+#     # Track shift for streaming continuity (start_pos is always a multiple of rf)
+#     start_pos = self._noisebands_shift % band_len
+#     self._noisebands_shift = (self._noisebands_shift + total_len) % band_len
 
-    # General path: training or batch_size > 1
-    upsampled_amplitudes = amplitudes.repeat_interleave(rf, dim=-1)
-    signal = torch.zeros(batch_size, 1, total_len, dtype=upsampled_amplitudes.dtype, device=upsampled_amplitudes.device)
-    out_pos, nb_pos = 0, start_pos
-    while out_pos < total_len:
-      avail = band_len - nb_pos
-      take = min(avail, total_len - out_pos)
-      nb_chunk = noisebands[:, nb_pos:nb_pos+take]
-      amp_chunk = upsampled_amplitudes[:, :, out_pos:out_pos+take]
-      signal[:, :, out_pos:out_pos+take] = (amp_chunk * nb_chunk).sum(dim=1, keepdim=True)
-      out_pos += take; nb_pos = (nb_pos + take) % band_len
-    return signal
+#     # Apply band mask at control rate (mean is identical pre- vs post-upsample)
+#     if limit_components > 0:
+#       max_bands = max(int(self.n_params * (1 - limit_components)), 1)
+#       _, indices = torch.topk(amplitudes.mean(dim=-1), max_bands, dim=1)
+#       mask = torch.zeros(batch_size, self.n_params, 1, dtype=amplitudes.dtype, device=amplitudes.device)
+#       mask.scatter_(1, indices.unsqueeze(-1), 1)
+#       amplitudes = amplitudes * mask
 
-  @property
-  def _noisebands(self):
-    """Delegate the noisebands to the filterbank object."""
-    return self._filterbank.noisebands
+#     # Fast inference path (any batch size, including folded multichannel): periodic blocked BMM,
+#     # handles limit_components too. _nb_blocked: [n_blocks, n_filters, rf], each block = one
+#     # control frame's audio. All rows share the same noisebands and start_pos, so they are
+#     # batched together over the leading dim.
+#     if not self.training:
+#       n_blocks = self._nb_blocked.shape[0]
+#       start_block = start_pos // rf
+#       nb_blocked = self._nb_blocked.to(amplitudes.dtype)  # match dtype (noisebands are float64)
+#       out = torch.empty(batch_size, n_ctrl, rf, dtype=amplitudes.dtype, device=amplitudes.device)
+#       t, b = 0, start_block
+#       while t < n_ctrl:
+#         avail = n_blocks - b
+#         take = min(avail, n_ctrl - t)
+#         # amplitudes[:, :, t:t+take]: [B, n_filters, take]; nb_blocked[b:b+take]: [take, n_filters, rf].
+#         # Contract over filters per control frame -> [B, take, rf].
+#         out[:, t:t+take, :] = torch.einsum('bft,tfr->btr', amplitudes[:, :, t:t+take], nb_blocked[b:b+take])
+#         t += take; b = (b + take) % n_blocks
+#       return out.reshape(batch_size, 1, -1)
+
+#     # General path: training or batch_size > 1
+#     upsampled_amplitudes = amplitudes.repeat_interleave(rf, dim=-1)
+#     signal = torch.zeros(batch_size, 1, total_len, dtype=upsampled_amplitudes.dtype, device=upsampled_amplitudes.device)
+#     out_pos, nb_pos = 0, start_pos
+#     while out_pos < total_len:
+#       avail = band_len - nb_pos
+#       take = min(avail, total_len - out_pos)
+#       nb_chunk = noisebands[:, nb_pos:nb_pos+take]
+#       amp_chunk = upsampled_amplitudes[:, :, out_pos:out_pos+take]
+#       signal[:, :, out_pos:out_pos+take] = (amp_chunk * nb_chunk).sum(dim=1, keepdim=True)
+#       out_pos += take; nb_pos = (nb_pos + take) % band_len
+#     return signal
+
+#   @property
+#   def _noisebands(self):
+#     """Delegate the noisebands to the filterbank object."""
+#     return self._filterbank.noisebands
 
 
 @register_synth
@@ -364,6 +364,137 @@ class SineSynth(BaseSynth):
     # Generate and sum the sinewaves
     signal = torch.sum(amplitudes * torch.sin(phases), dim=1, keepdim=True)
     return signal
+
+@register_synth
+class NoiseBandSynth(BaseSynth):
+  """
+  A synthesiser that generates a mixture noise bands from amplitudes.
+
+  Arguments:
+    - n_filters: int, the number of filters in the filterbank
+    - fs: int, the sampling rate of the input signal
+    - resampling_factor: int, the internal up / down sampling factor for the signal
+    - device: str, the device to use
+  """
+
+  def __init__(self, n_filters: int = 2048, fs: int = 44100, resampling_factor: int = 32, device: str = 'cuda'):
+    super().__init__()
+    self._resampling_factor = resampling_factor
+    self._device = device
+
+    self._filterbank = FilterBank(
+      n_filters=n_filters,
+      fs=fs,
+      device=self._device
+    )
+
+    # Shift of the noisebands between inferences, to maintain continuity
+    self._noisebands_shift = 0
+
+    # NOTE: the fast batch=1 path needs a [n_blocks, n_filters, rf] "blocked" view of
+    # `noisebands`. That view is a pure reshape+permute (zero-copy) of the existing
+    # `noisebands` buffer, so we derive it on the fly in forward() instead of storing a
+    # second, .contiguous() resident copy here. Keeping that copy doubled the resident
+    # noise-bank memory (mem exp1).
+
+
+  @property
+  def n_params(self):
+    return len(self._filterbank.noisebands)
+
+
+  @property
+  def jit_name(self):
+    return "NoiseBandSynth"
+
+
+  def forward(self, amplitudes: torch.Tensor, limit_components: float = 0.0, waveshaping_factor: float = 0.0) -> torch.Tensor:
+    """
+    Synthesizes a signal from the predicted amplitudes and the baked noise bands.
+    Args:
+      - amplitudes: torch.Tensor[batch_size, n_bands, n_ctrl], the predicted amplitudes of the noise bands
+      - limit_components: float, the attenuation factor for the number of used bands
+      - waveshaping_factor: float, does nothing, it is here for the JIT compatibility with other synth classes
+    Returns:
+      - signal: torch.Tensor[batch_size, 1, sig_length], the synthesized signal
+    """
+    limit_components = max(0.0, min(limit_components, 1.0))
+    rf = int(self._resampling_factor)
+    noisebands = self._noisebands  # int8 [n_filters, band_len] (mem exp3)
+    nb_scale = self._filterbank.noisebands_scale  # [n_filters] per-band; dequant = int8_slice.float() * scale[:,None]
+    band_len = noisebands.shape[-1]
+    n_ctrl = amplitudes.shape[-1]
+    total_len = n_ctrl * rf
+    batch_size = amplitudes.shape[0]
+
+    if self.training:
+      # Roll noisebands randomly during training to avoid overfitting to specific noise values
+      noisebands = torch.roll(noisebands, shifts=int(torch.randint(0, band_len, size=(1,), device=noisebands.device)), dims=-1)
+
+    # Track shift for streaming continuity (start_pos is always a multiple of rf)
+    start_pos = self._noisebands_shift % band_len
+    self._noisebands_shift = (self._noisebands_shift + total_len) % band_len
+
+    if limit_components > 0:
+      upsampled_amplitudes = amplitudes.repeat_interleave(rf, dim=-1)
+      max_bands = max(int(self.n_params * (1 - limit_components)), 1)
+      mean_amps = upsampled_amplitudes.mean(dim=-1)
+      _, indices = torch.topk(mean_amps, max_bands, dim=1)
+      mask = torch.zeros_like(upsampled_amplitudes)
+      mask.scatter_(1, indices.unsqueeze(-1).expand(-1, -1, total_len), 1)
+      upsampled_amplitudes = upsampled_amplitudes * mask
+      signal = torch.zeros(batch_size, 1, total_len, dtype=upsampled_amplitudes.dtype, device=upsampled_amplitudes.device)
+      out_pos, nb_pos = 0, start_pos
+      while out_pos < total_len:
+        avail = band_len - nb_pos
+        take = min(avail, total_len - out_pos)
+        nb_seg = noisebands[:, nb_pos:nb_pos+take].to(torch.float32) * nb_scale.unsqueeze(-1)
+        signal[:, :, out_pos:out_pos+take] = (upsampled_amplitudes[:, :, out_pos:out_pos+take] * nb_seg).sum(1, keepdim=True)
+        out_pos += take; nb_pos = (nb_pos + take) % band_len
+      return signal
+
+    # Fast inference path for batch_size=1 and no limit_components:
+    # Periodic blocked BMM — avoids repeat_interleave and processes at control rate.
+    # _nb_blocked: [n_blocks, n_filters, rf], each block = one control frame's audio.
+    if not self.training and batch_size == 1:
+      # Blocked view [n_blocks, n_filters, rf] derived as a zero-copy reshape+permute
+      # of `noisebands` [n_filters, band_len]; no second resident copy (mem exp1).
+      n_f = noisebands.shape[0]
+      n_blocks = band_len // rf
+      nb_blocked = noisebands.reshape(n_f, n_blocks, rf).permute(1, 0, 2)
+      start_block = start_pos // rf
+      # Fold the per-band scale into the amplitudes (cheap: [n_ctrl, n_filters]) instead of
+      # scaling the large noise slices — out = Σ_f amp_f·(int8_f·scale_f) (mem exp3).
+      amp_T = amplitudes.squeeze(0).T * nb_scale.unsqueeze(0)  # [n_ctrl, n_filters]
+      out = torch.empty(n_ctrl, rf, dtype=amplitudes.dtype, device=amplitudes.device)
+      t, b = 0, start_block
+      while t < n_ctrl:
+        avail = n_blocks - b
+        take = min(avail, n_ctrl - t)
+        # nb_blocked[b:b+take] is a (non-contiguous) int8 view; convert just this small
+        # per-segment slice to float (never the full table), then bmm against scaled amps.
+        nb_seg = nb_blocked[b:b+take].to(torch.float32)
+        out[t:t+take] = torch.bmm(amp_T[t:t+take].unsqueeze(1), nb_seg).squeeze(1)
+        t += take; b = (b + take) % n_blocks
+      return out.reshape(1, 1, -1)
+
+    # General path: training or batch_size > 1
+    upsampled_amplitudes = amplitudes.repeat_interleave(rf, dim=-1)
+    signal = torch.zeros(batch_size, 1, total_len, dtype=upsampled_amplitudes.dtype, device=upsampled_amplitudes.device)
+    out_pos, nb_pos = 0, start_pos
+    while out_pos < total_len:
+      avail = band_len - nb_pos
+      take = min(avail, total_len - out_pos)
+      nb_chunk = noisebands[:, nb_pos:nb_pos+take].to(torch.float32) * nb_scale.unsqueeze(-1)
+      amp_chunk = upsampled_amplitudes[:, :, out_pos:out_pos+take]
+      signal[:, :, out_pos:out_pos+take] = (amp_chunk * nb_chunk).sum(dim=1, keepdim=True)
+      out_pos += take; nb_pos = (nb_pos + take) % band_len
+    return signal
+
+  @property
+  def _noisebands(self):
+    """Delegate the noisebands to the filterbank object."""
+    return self._filterbank.noisebands
 
 @register_synth
 class BendableNoiseBandSynth(BaseSynth):

--- a/ddsp/synths/synths.py
+++ b/ddsp/synths/synths.py
@@ -5,7 +5,7 @@ import torchaudio
 import torch.nn.functional as F
 import numpy as np
 
-from ddsp.filterbank import FilterBank, LazyFilterBank
+from ddsp.filterbank import FilterBank
 # from ddsp.sgd.sinusoidal_gradient_descent.core import complex_oscillator
 
 
@@ -69,124 +69,6 @@ class BaseSynth(nn.Module):
 
     cls = _SYNTH_REGISTRY[cls_name]
     return cls(**params)
-
-
-# @register_synth
-# class NoiseBandSynth(BaseSynth):
-#   """
-#   A synthesiser that generates a mixture noise bands from amplitudes.
-
-#   Arguments:
-#     - n_filters: int, the number of filters in the filterbank
-#     - fs: int, the sampling rate of the input signal
-#     - resampling_factor: int, the internal up / down sampling factor for the signal
-#     - device: str, the device to use
-#   """
-
-#   def __init__(self, n_filters: int = 2048, fs: int = 44100, resampling_factor: int = 32, device: str = 'cuda'):
-#     super().__init__()
-#     self._resampling_factor = resampling_factor
-#     self._device = device
-
-#     self._filterbank = FilterBank(
-#       n_filters=n_filters,
-#       fs=fs,
-#       device=self._device
-#     )
-
-#     # Shift of the noisebands between inferences, to maintain continuity
-#     self._noisebands_shift = 0
-
-#     # Precompute blocked noisebands for fast batch=1 inference synthesis.
-#     # Reshape [n_filters, band_len] -> [n_blocks, n_filters, rf] where n_blocks = band_len // rf
-#     # Each block corresponds to one control frame's worth of audio samples.
-#     nb = self._filterbank.noisebands # [n_filters, band_len]
-#     n_f, band_len = nb.shape
-#     n_blocks = band_len // resampling_factor
-#     nb_blocked = nb.reshape(n_f, n_blocks, resampling_factor).permute(1, 0, 2).contiguous()
-#     self.register_buffer('_nb_blocked', nb_blocked, persistent=False) # -> [n_blocks, n_filters, rf]
-
-
-#   @property
-#   def n_params(self):
-#     return len(self._filterbank.noisebands)
-
-
-#   @property
-#   def jit_name(self):
-#     return "NoiseBandSynth"
-
-
-#   def forward(self, amplitudes: torch.Tensor, limit_components: float = 0.0, waveshaping_factor: float = 0.0) -> torch.Tensor:
-#     """
-#     Synthesizes a signal from the predicted amplitudes and the baked noise bands.
-#     Args:
-#       - amplitudes: torch.Tensor[batch_size, n_bands, n_ctrl], the predicted amplitudes of the noise bands
-#       - limit_components: float, the attenuation factor for the number of used bands
-#       - waveshaping_factor: float, does nothing, it is here for the JIT compatibility with other synth classes
-#     Returns:
-#       - signal: torch.Tensor[batch_size, 1, sig_length], the synthesized signal
-#     """
-#     limit_components = max(0.0, min(limit_components, 1.0))
-#     rf = int(self._resampling_factor)
-#     noisebands = self._noisebands  # [n_filters, band_len]
-#     band_len = noisebands.shape[-1]
-#     n_ctrl = amplitudes.shape[-1]
-#     total_len = n_ctrl * rf
-#     batch_size = amplitudes.shape[0]
-
-#     if self.training:
-#       # Roll noisebands randomly during training to avoid overfitting to specific noise values
-#       noisebands = torch.roll(noisebands, shifts=int(torch.randint(0, band_len, size=(1,), device=noisebands.device)), dims=-1)
-
-#     # Track shift for streaming continuity (start_pos is always a multiple of rf)
-#     start_pos = self._noisebands_shift % band_len
-#     self._noisebands_shift = (self._noisebands_shift + total_len) % band_len
-
-#     # Apply band mask at control rate (mean is identical pre- vs post-upsample)
-#     if limit_components > 0:
-#       max_bands = max(int(self.n_params * (1 - limit_components)), 1)
-#       _, indices = torch.topk(amplitudes.mean(dim=-1), max_bands, dim=1)
-#       mask = torch.zeros(batch_size, self.n_params, 1, dtype=amplitudes.dtype, device=amplitudes.device)
-#       mask.scatter_(1, indices.unsqueeze(-1), 1)
-#       amplitudes = amplitudes * mask
-
-#     # Fast inference path (any batch size, including folded multichannel): periodic blocked BMM,
-#     # handles limit_components too. _nb_blocked: [n_blocks, n_filters, rf], each block = one
-#     # control frame's audio. All rows share the same noisebands and start_pos, so they are
-#     # batched together over the leading dim.
-#     if not self.training:
-#       n_blocks = self._nb_blocked.shape[0]
-#       start_block = start_pos // rf
-#       nb_blocked = self._nb_blocked.to(amplitudes.dtype)  # match dtype (noisebands are float64)
-#       out = torch.empty(batch_size, n_ctrl, rf, dtype=amplitudes.dtype, device=amplitudes.device)
-#       t, b = 0, start_block
-#       while t < n_ctrl:
-#         avail = n_blocks - b
-#         take = min(avail, n_ctrl - t)
-#         # amplitudes[:, :, t:t+take]: [B, n_filters, take]; nb_blocked[b:b+take]: [take, n_filters, rf].
-#         # Contract over filters per control frame -> [B, take, rf].
-#         out[:, t:t+take, :] = torch.einsum('bft,tfr->btr', amplitudes[:, :, t:t+take], nb_blocked[b:b+take])
-#         t += take; b = (b + take) % n_blocks
-#       return out.reshape(batch_size, 1, -1)
-
-#     # General path: training or batch_size > 1
-#     upsampled_amplitudes = amplitudes.repeat_interleave(rf, dim=-1)
-#     signal = torch.zeros(batch_size, 1, total_len, dtype=upsampled_amplitudes.dtype, device=upsampled_amplitudes.device)
-#     out_pos, nb_pos = 0, start_pos
-#     while out_pos < total_len:
-#       avail = band_len - nb_pos
-#       take = min(avail, total_len - out_pos)
-#       nb_chunk = noisebands[:, nb_pos:nb_pos+take]
-#       amp_chunk = upsampled_amplitudes[:, :, out_pos:out_pos+take]
-#       signal[:, :, out_pos:out_pos+take] = (amp_chunk * nb_chunk).sum(dim=1, keepdim=True)
-#       out_pos += take; nb_pos = (nb_pos + take) % band_len
-#     return signal
-
-#   @property
-#   def _noisebands(self):
-#     """Delegate the noisebands to the filterbank object."""
-#     return self._filterbank.noisebands
 
 
 @register_synth


### PR DESCRIPTION
### Noise bank memory (`filterbank.py`, `synths.py`)
  - Store `noisebands` as **int8 + per-band float scale** instead of float32 (4× smaller); dequant only the small slices actually used.
  - Drop the duplicate `_nb_blocked` buffer — derive it on the fly as a zero-copy
  `reshape+permute` view.
  - Noise buffers are now `persistent=False` (regenerated at startup, out of the
  checkpoint).

  ### Multichannel prior caching (`prior/lmdb_cache.py`)
  - Add `n_channels` to the cache key; treat audio as channel-first and chunk along time.
  - Clamp `z`/feature time dims to the shared min so trailing partial chunks don't go off by ±1.

  ### β warmup (`cli/train.py`, `ddsp.py`, configs)
  - Epoch-based `BetaWarmupEpochCallback` via a `model.beta` block (`target`/`start_epoch`/`end_epoch`).
  - Restore fixed `_KLD_WEIGHT = 0.0001`: loss is `recons + _KLD_WEIGHT * β * kld`.